### PR TITLE
Hotfix update #13 for trigger-jenkins.yml

### DIFF
--- a/.github/workflows/trigger-jenkins.yml
+++ b/.github/workflows/trigger-jenkins.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Build SampleJob
       run: |
-        curl -X POST -L --user admin:112620f71562476991a059bc747ecf733e http://54.221.6.255:8080/job/SampleJob/buildWithParameters/?PARAMETER=GIT_BRANCH
+        curl -X POST -L --user admin:${{ secrets.TOKEN }} http://54.221.6.255:8080/job/SampleJob/buildWithParameters/?PARAMETER=GIT_BRANCH
         
   close_job:
     # this job will only run if the PR has been closed without being merged


### PR DESCRIPTION
Same as hotfix-12, but now we censor the API token using a GitHub secret